### PR TITLE
include polars cpu compatibility build

### DIFF
--- a/triplifier/data_descriptor/templates/footer.html
+++ b/triplifier/data_descriptor/templates/footer.html
@@ -18,7 +18,7 @@
                 <a href="https://github.com/MaastrichtU-CDS/Flyover" target="_blank" class="footer-link">
                     <p class="footer-text">
                         <i class="fas fa-code"></i>
-                        <strong>Flyover</strong> v2.1.0
+                        <strong>Flyover</strong> v2.1.1
                     </p>
                 </a>
             </div>

--- a/triplifier/requirements.txt
+++ b/triplifier/requirements.txt
@@ -5,7 +5,7 @@ Flask-Compress==1.17
 Flask-SQLAlchemy==3.1.1
 gevent==25.9.1
 gunicorn==23.0.0
-polars==1.36.1
+polars[rtcompat]==1.36.1
 psycopg2-binary==2.9.10
 python-dateutil==2.9.0.post0
 pytz==2025.2


### PR DESCRIPTION
Mistral:
Using polars[rtcompat] ensures the best of both worlds:

On modern CPUs (with AVX2/FMA/etc.), Polars will use fully optimised, vectorised operations for maximum performance.
On older or unsupported CPUs, it gracefully falls back to a compatibility mode, avoiding crashes while maintaining functionality.
This approach guarantees robust deployment across unknown systems—whether x86-64, ARM, or legacy hardware—without sacrificing performance where modern features are available.

