### PR TITLE
Remove redundant variable key from column data

### DIFF
--- a/triplifier/data_descriptor/assets/js/jsonld-mapper.js
+++ b/triplifier/data_descriptor/assets/js/jsonld-mapper.js
@@ -15,7 +15,7 @@ const JSONLDMapper = {
     },
 
     getVariableKeyFromColumn: function(colData) {
-        return colData.variable || colData.mapsTo?.split('/').pop();
+        return colData.mapsTo?.split('/').pop();
     },
 
     normalizeLocalMappings: function(localMappings) {
@@ -149,7 +149,7 @@ const JSONLDMapper = {
 
         let result = varKey;
         this.forEachColumn(this.mapping.databases, (colData) => {
-            if (colData.variable === varKey || colData.mapsTo === `schema:variable/${varKey}`) {
+            if (colData.mapsTo === `schema:variable/${varKey}`) {
                 result = colData.localColumn || varKey;
                 return false;
             }
@@ -474,7 +474,6 @@ const JSONLDMapper = {
                     colData.localColumn = localVariable;
 
                     if (newGlobalVariable !== globalVariable) {
-                        colData.variable = newGlobalVariable;
                         colData.mapsTo = `schema:variable/${newGlobalVariable}`;
                     }
 

--- a/triplifier/data_descriptor/templates/annotation_review.html
+++ b/triplifier/data_descriptor/templates/annotation_review.html
@@ -661,10 +661,8 @@
                     if (!colData.localColumn) continue;
 
                     // Extract variable name from mapsTo
-                    let varName = colData.variable;
-                    if (!varName && colData.mapsTo) {
-                        varName = colData.mapsTo.split('/').pop();
-                    }
+                    if (!colData.mapsTo) continue;
+                    const varName = colData.mapsTo.split('/').pop();
                     if (!varName) continue;
 
                     // Get the schema variable info


### PR DESCRIPTION
The variable key on column data was redundant since mapsTo already contains the same information. All code paths now use mapsTo directly.