### PR TITLE
Add table selection and clarify semantic map submission in tests

### DIFF
--- a/triplifier/backend/data_descriptor/controllers/annotate_controller.py
+++ b/triplifier/backend/data_descriptor/controllers/annotate_controller.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import tempfile
+from typing import Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from flask import Blueprint, jsonify, redirect, request
@@ -29,6 +30,72 @@ def get_app_context() -> dict:
     from flask import current_app
 
     return current_app.config.get("APP_CONTEXT", {})
+
+
+def _extract_filtered_semantic_map(request_data: dict) -> Optional[dict]:
+    """
+    Extract filtered semantic map from request data.
+
+    The frontend may send the filtered semantic map either:
+    - Wrapped in a "semantic_map" key, or
+    - As the raw request body itself
+
+    Returns None if no valid filtered map is provided.
+    """
+    if not request_data:
+        return None
+
+    filtered_semantic_map = (
+        request_data.get("semantic_map") if isinstance(request_data, dict) else None
+    )
+
+    # If not wrapped in a "semantic_map" key, the body itself may be the map
+    if filtered_semantic_map is None and request_data:
+        filtered_semantic_map = request_data
+
+    # Treat an empty dict as "no filter provided"
+    if not filtered_semantic_map:
+        return None
+
+    return filtered_semantic_map
+
+
+def _apply_filtered_semantic_map(
+    session_cache, filtered_semantic_map: dict
+) -> Optional[dict]:
+    """
+    Validate and temporarily apply a filtered semantic map for this annotation run.
+
+    Returns the original semantic map that was replaced, or None if no filter was applied.
+
+    The original map should be restored after annotation completes so that
+    the Share page (and every other route) continues to see the full map.
+    """
+    if not filtered_semantic_map:
+        return None
+
+    # Validate the filtered semantic map before using it
+    validator = MappingValidator()
+    validation_result = validator.validate(filtered_semantic_map)
+    if not validation_result.is_valid:
+        return None
+
+    original_semantic_map = session_cache.jsonld_mapping
+    session_cache.jsonld_mapping = JSONLDMapping.from_dict(filtered_semantic_map)
+    return original_semantic_map
+
+
+def _restore_original_semantic_map(
+    session_cache, original_semantic_map: Optional[dict]
+) -> None:
+    """
+    Restore the original semantic map after annotation completes.
+
+    This ensures the Share page and all other routes are never affected
+    by the per-run filter.
+    """
+    if original_semantic_map is not None:
+        session_cache.jsonld_mapping = original_semantic_map
 
 
 def safe_remove_file(filepath: str) -> None:
@@ -144,8 +211,8 @@ def upload_annotation_json():
                     400,
                 )
 
-            # Clean the mapping of orphan columns right at the start
-            # This ensures faulty mappings don't persist anywhere
+            # Clean the mapping of orphan columns right at the start.
+            # This ensures faulty mappings don't persist anywhere.
             removed_columns = []
             try:
                 if rdf_store_service is not None:
@@ -153,9 +220,6 @@ def upload_annotation_json():
                         rdf_store_service.get_column_info_by_database() or {}
                     )
                     if columns_by_database:
-                        # Get loaded databases - use the databases list we already fetched
-                        loaded_databases = databases
-
                         from .ingest_controller import (
                             _collect_orphan_column_issues,
                             _remove_orphan_columns_from_mapping,
@@ -163,11 +227,10 @@ def upload_annotation_json():
 
                         orphan_warnings, _, orphan_columns = (
                             _collect_orphan_column_issues(
-                                json_data, columns_by_database, loaded_databases
+                                json_data, columns_by_database, databases
                             )
                         )
 
-                        # Clean the mapping immediately, before validation
                         if orphan_columns:
                             json_data = _remove_orphan_columns_from_mapping(
                                 json_data, orphan_columns
@@ -181,11 +244,9 @@ def upload_annotation_json():
             except Exception as e:
                 logger.warning(f"Orphan column check skipped: {e}")
 
-            # Use the cleaned mapping for both session cache entries
             session_cache.global_semantic_map = json_data
             session_cache.annotation_json_path = filepath
 
-            # Now validate the cleaned mapping
             validator = MappingValidator()
             result = validator.validate(json_data)
             if result.is_valid:
@@ -231,35 +292,20 @@ def start_annotation():
     get_table_names = ctx.get("get_table_names")
     has_semantic_map = ctx.get("has_semantic_map")
 
-    # Check if request contains a filtered semantic map for this annotation run.
-    # The frontend sends the filtered semantic map directly as the request body.
     request_data = request.get_json(silent=True) or {}
-    filtered_semantic_map = (
-        request_data.get("semantic_map") if isinstance(request_data, dict) else None
+    filtered_semantic_map = _extract_filtered_semantic_map(request_data)
+
+    # Temporarily apply filtered semantic map for this annotation run only.
+    # The original is always restored afterwards so that the Share page
+    # (and every other route) continues to see the full map.
+    original_semantic_map = _apply_filtered_semantic_map(
+        session_cache, filtered_semantic_map
     )
-    # If not wrapped in a "semantic_map" key, the body itself may be the map
-    if filtered_semantic_map is None and request_data:
-        filtered_semantic_map = request_data
 
-    # Treat an empty dict as "no filter provided"
-    if not filtered_semantic_map:
-        filtered_semantic_map = None
-
-    # If a filtered semantic map is provided, temporarily swap it into the session
-    # for this annotation run only. The original is always restored afterwards so
-    # that the Share page (and every other route) continues to see the full map.
-    original_semantic_map = None
-    if filtered_semantic_map:
-        # Validate the filtered semantic map before using it
-        validator = MappingValidator()
-        validation_result = validator.validate(filtered_semantic_map)
-        if not validation_result.is_valid:
-            return jsonify(
-                {"success": False, "error": "Filtered semantic map validation failed"}
-            )
-
-        original_semantic_map = session_cache.jsonld_mapping
-        session_cache.jsonld_mapping = JSONLDMapping.from_dict(filtered_semantic_map)
+    if original_semantic_map is None and filtered_semantic_map:
+        return jsonify(
+            {"success": False, "error": "Filtered semantic map validation failed"}
+        )
 
     try:
         if not has_semantic_map(session_cache):
@@ -381,8 +427,7 @@ def start_annotation():
     finally:
         # Always restore the original (full) semantic map so that the Share
         # page and all other routes are never affected by the per-run filter.
-        if original_semantic_map is not None:
-            session_cache.jsonld_mapping = original_semantic_map
+        _restore_original_semantic_map(session_cache, original_semantic_map)
 
 
 @annotate_bp.route("/annotation-verify")

--- a/triplifier/backend/data_descriptor/controllers/annotate_controller.py
+++ b/triplifier/backend/data_descriptor/controllers/annotate_controller.py
@@ -230,6 +230,35 @@ def start_annotation():
     name_matcher = ctx.get("name_matcher")
     get_table_names = ctx.get("get_table_names")
     has_semantic_map = ctx.get("has_semantic_map")
+    
+    # Check if request contains a filtered semantic map for this annotation run.
+    # The frontend sends the filtered semantic map directly as the request body.
+    request_data = request.get_json(silent=True) or {}
+    filtered_semantic_map = request_data.get("semantic_map") if isinstance(request_data, dict) else None
+    # If not wrapped in a "semantic_map" key, the body itself may be the map
+    if filtered_semantic_map is None and request_data:
+        filtered_semantic_map = request_data
+
+    # Treat an empty dict as "no filter provided"
+    if not filtered_semantic_map:
+        filtered_semantic_map = None
+
+    # If a filtered semantic map is provided, temporarily swap it into the session
+    # for this annotation run only. The original is always restored afterwards so
+    # that the Share page (and every other route) continues to see the full map.
+    original_semantic_map = None
+    if filtered_semantic_map:
+        # Validate the filtered semantic map before using it
+        validator = MappingValidator()
+        validation_result = validator.validate(filtered_semantic_map)
+        if not validation_result.is_valid:
+            return jsonify({
+                "success": False,
+                "error": "Filtered semantic map validation failed"
+            })
+
+        original_semantic_map = session_cache.jsonld_mapping
+        session_cache.jsonld_mapping = JSONLDMapping.from_dict(filtered_semantic_map)
 
     try:
         if not has_semantic_map(session_cache):
@@ -347,6 +376,12 @@ def start_annotation():
     except Exception as e:
         logger.error(f"Annotation error: {e}")
         return jsonify({"success": False, "error": str(e)})
+
+    finally:
+        # Always restore the original (full) semantic map so that the Share
+        # page and all other routes are never affected by the per-run filter.
+        if original_semantic_map is not None:
+            session_cache.jsonld_mapping = original_semantic_map
 
 
 @annotate_bp.route("/annotation-verify")

--- a/triplifier/backend/data_descriptor/controllers/annotate_controller.py
+++ b/triplifier/backend/data_descriptor/controllers/annotate_controller.py
@@ -230,11 +230,13 @@ def start_annotation():
     name_matcher = ctx.get("name_matcher")
     get_table_names = ctx.get("get_table_names")
     has_semantic_map = ctx.get("has_semantic_map")
-    
+
     # Check if request contains a filtered semantic map for this annotation run.
     # The frontend sends the filtered semantic map directly as the request body.
     request_data = request.get_json(silent=True) or {}
-    filtered_semantic_map = request_data.get("semantic_map") if isinstance(request_data, dict) else None
+    filtered_semantic_map = (
+        request_data.get("semantic_map") if isinstance(request_data, dict) else None
+    )
     # If not wrapped in a "semantic_map" key, the body itself may be the map
     if filtered_semantic_map is None and request_data:
         filtered_semantic_map = request_data
@@ -252,10 +254,9 @@ def start_annotation():
         validator = MappingValidator()
         validation_result = validator.validate(filtered_semantic_map)
         if not validation_result.is_valid:
-            return jsonify({
-                "success": False,
-                "error": "Filtered semantic map validation failed"
-            })
+            return jsonify(
+                {"success": False, "error": "Filtered semantic map validation failed"}
+            )
 
         original_semantic_map = session_cache.jsonld_mapping
         session_cache.jsonld_mapping = JSONLDMapping.from_dict(filtered_semantic_map)

--- a/triplifier/backend/data_descriptor/tests/unit/test_controllers.py
+++ b/triplifier/backend/data_descriptor/tests/unit/test_controllers.py
@@ -623,5 +623,125 @@ class TestAnnotateControllerLanding(unittest.TestCase):
         self.assertEqual(response.headers.get("Location"), "/annotate")
 
 
+class TestAnnotateControllerStartAnnotationFiltering(unittest.TestCase):
+    """Tests for POST /start-annotation with a filtered semantic map.
+
+    The key invariant under test: when a filtered semantic map is submitted the
+    session_cache.jsonld_mapping must be restored to its original value after
+    the request completes — regardless of whether annotation succeeds or fails.
+    This ensures that the Share page (and every other route) always sees the
+    full, unfiltered map.
+    """
+
+    # A minimal valid JSON-LD map used as the "full" session map.
+    _FULL_MAP = _MINIMAL_VALID_JSONLD
+
+    # A filtered subset that removes the only database.
+    _FILTERED_MAP = {
+        "@context": {"@vocab": "https://github.com/MaastrichtU-CDS/Flyover/"},
+        "@type": "mapping:DataMapping",
+        "name": "Test Mapping",
+        "schema": {
+            "@type": "schema:SemanticSchema",
+            "variables": {
+                "identifier": {
+                    "@type": "schema:IdentifierVariable",
+                    "dataType": "identifier",
+                    "predicate": "sio:SIO_000673",
+                    "class": "ncit:C25364",
+                }
+            },
+        },
+        "databases": {},  # empty — only selected table removed
+    }
+
+    def _make_annotate_app(self, prepare_return=None, execute_return=None):
+        """Build a minimal Flask app whose AnnotateService is fully mocked."""
+        from unittest.mock import patch, MagicMock
+
+        app = Flask(
+            __name__,
+            template_folder=str(Path(__file__).parent.parent.parent / "templates"),
+        )
+        app.secret_key = "test-secret"
+
+        original_mapping = MagicMock()
+        mock_session = MagicMock()
+        mock_session.jsonld_mapping = original_mapping
+        mock_session.annotation_status = {}
+        mock_session.repo = "test_repo"
+
+        mock_rdf = MagicMock()
+        mock_rdf.get_databases.return_value = ["test_db"]
+
+        app.config["APP_CONTEXT"] = {
+            "session_cache": mock_session,
+            "rdf_store_service": mock_rdf,
+            "rdf_store_url": "http://localhost:7200",
+            "upload_folder": "/tmp",
+            "formulate_local_map": MagicMock(return_value={}),
+            "get_semantic_map": MagicMock(return_value={}),
+            "get_table_names": MagicMock(return_value=["test_table"]),
+            "has_semantic_map": MagicMock(return_value=True),
+            "name_matcher": MagicMock(return_value=True),
+        }
+        app.register_blueprint(annotate_bp)
+        return app, mock_session, original_mapping
+
+    def test_filtered_map_does_not_permanently_replace_session_mapping(self):
+        """After a filtered annotation, the original mapping must be restored."""
+        from unittest.mock import patch, MagicMock
+
+        app, mock_session, original_mapping = self._make_annotate_app()
+
+        with app.test_client() as client:
+            with patch(
+                "controllers.annotate_controller.AnnotateService.prepare_annotation_data",
+                return_value={},  # no annotation data → early return, still hits finally
+            ), patch(
+                "controllers.annotate_controller.MappingValidator"
+            ) as MockValidator:
+                mock_result = MagicMock()
+                mock_result.is_valid = True
+                MockValidator.return_value.validate.return_value = mock_result
+
+                response = client.post(
+                    "/start-annotation",
+                    data=json.dumps(self._FILTERED_MAP),
+                    content_type="application/json",
+                )
+
+        # The request should complete (success=False is fine because there is
+        # no annotation data), but crucially the mapping must be restored.
+        self.assertIsNotNone(response)
+        self.assertIs(
+            mock_session.jsonld_mapping,
+            original_mapping,
+            "session_cache.jsonld_mapping was not restored to the original after "
+            "a filtered annotation run — this would break the Share page.",
+        )
+
+    def test_no_filtered_map_leaves_session_mapping_unchanged(self):
+        """When no filtered map is sent, the session mapping must not be touched."""
+        from unittest.mock import patch, MagicMock
+
+        app, mock_session, original_mapping = self._make_annotate_app()
+
+        with app.test_client() as client:
+            with patch(
+                "controllers.annotate_controller.AnnotateService.prepare_annotation_data",
+                return_value={},
+            ):
+                # POST with no body → no filtered map
+                response = client.post("/start-annotation")
+
+        self.assertIs(
+            mock_session.jsonld_mapping,
+            original_mapping,
+            "session_cache.jsonld_mapping should never be altered when no filtered "
+            "map is provided.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/triplifier/frontend/src/views/AnnotationReviewView.vue
+++ b/triplifier/frontend/src/views/AnnotationReviewView.vue
@@ -325,7 +325,12 @@ function createFilteredSemanticMap(selectedTableNames) {
   
   if (!filteredMap.databases) return filteredMap
 
-  // Remove unselected tables
+  removeUnselectedTables(filteredMap, selectedSet)
+
+  return filteredMap
+}
+
+function removeUnselectedTables(filteredMap, selectedSet) {
   for (const dbKey in filteredMap.databases) {
     const db = filteredMap.databases[dbKey]
     if (!db.tables) continue
@@ -341,8 +346,70 @@ function createFilteredSemanticMap(selectedTableNames) {
       delete filteredMap.databases[dbKey]
     }
   }
+}
 
-  return filteredMap
+function validateTableSelection() {
+  if (!Object.values(selectedTables).some(selected => selected)) {
+    alert('Please select at least one table to annotate.')
+    return false
+  }
+  return true
+}
+
+function getSelectedTableNames() {
+  return Object.entries(selectedTables)
+    .filter(([tableName, isSelected]) => isSelected)
+    .map(([tableName]) => tableName)
+}
+
+function validateFilteredMapHasTables(filteredSemanticMap) {
+  const hasTables = Object.values(filteredSemanticMap.databases || {}).some(db => 
+    Object.keys(db.tables || {}).length > 0
+  )
+  if (!hasTables) {
+    alert('No tables selected for annotation')
+    return false
+  }
+  return true
+}
+
+function resetAnnotationProcessingState() {
+  annotationProcessing.value = false
+  annotationButtonText.value = 'Start Annotation Process'
+}
+
+async function submitFullSemanticMap() {
+  const submitRes = await fetch('/submit-indexeddb-semantic-map', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(semanticMapData.value),
+  })
+  const submit = await submitRes.json()
+  
+  if (!submitRes.ok || !submit.success) {
+    let msg = submit.error || 'Failed to submit semantic map.'
+    if (submit.validation_errors?.length) {
+      msg += '\n\nValidation errors:\n' + submit.validation_errors.map((e) => `- ${e.message}`).join('\n')
+    }
+    alert(msg)
+    return false
+  }
+  return true
+}
+
+async function startAnnotationWithFilteredMap(filteredSemanticMap) {
+  const annRes = await fetch('/start-annotation', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(filteredSemanticMap),
+  })
+  const ann = await annRes.json()
+  
+  if (!ann.success) {
+    alert(`Error: ${ann.error}`)
+    return false
+  }
+  return true
 }
 
 async function startAnnotationProcess() {
@@ -351,73 +418,38 @@ async function startAnnotationProcess() {
     return
   }
   
-  // Check if any tables are selected
-  const anySelected = Object.values(selectedTables).some(selected => selected)
-  if (!anySelected) {
-    alert('Please select at least one table to annotate.')
-    return
-  }
+  if (!validateTableSelection()) return
   
   annotationProcessing.value = true
   annotationButtonText.value = 'Submitting semantic map...'
   try {
-    // Get the selected table names
-    const selectedTableNames = Object.entries(selectedTables)
-      .filter(([tableName, isSelected]) => isSelected)
-      .map(([tableName]) => tableName)
-
-    // Create a filtered semantic map that only includes selected tables
+    const selectedTableNames = getSelectedTableNames()
     const filteredSemanticMap = createFilteredSemanticMap(selectedTableNames)
     
-    // Ensure we don't send empty semantic map
-    const hasTables = Object.values(filteredSemanticMap.databases || {}).some(db => 
-      Object.keys(db.tables || {}).length > 0
-    )
-    if (!hasTables) {
-      alert('No tables selected for annotation')
-      annotationProcessing.value = false
-      annotationButtonText.value = 'Start Annotation Process'
+    if (!validateFilteredMapHasTables(filteredSemanticMap)) {
+      resetAnnotationProcessingState()
       return
     }
 
     // Send FULL semantic map to preserve original for Share page
-    const submitRes = await fetch('/submit-indexeddb-semantic-map', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(semanticMapData.value),
-    })
-    const submit = await submitRes.json()
-    if (!submitRes.ok || !submit.success) {
-      let msg = submit.error || 'Failed to submit semantic map.'
-      if (submit.validation_errors?.length) {
-        msg += '\n\nValidation errors:\n' + submit.validation_errors.map((e) => `- ${e.message}`).join('\n')
-      }
-      alert(msg)
-      annotationProcessing.value = false
-      annotationButtonText.value = 'Start Annotation Process'
+    const submitSuccess = await submitFullSemanticMap()
+    if (!submitSuccess) {
+      resetAnnotationProcessingState()
       return
     }
+    
     annotationButtonText.value = 'Processing Annotations...'
     
-    // Try sending filtered map to annotation endpoint
-    const annRes = await fetch('/start-annotation', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(filteredSemanticMap),
-    })
-    const ann = await annRes.json()
-    if (ann.success) {
+    const annotationSuccess = await startAnnotationWithFilteredMap(filteredSemanticMap)
+    if (annotationSuccess) {
       router.push('/annotate/verify')
     } else {
-      alert(`Error: ${ann.error}`)
-      annotationProcessing.value = false
-      annotationButtonText.value = 'Start Annotation Process'
+      resetAnnotationProcessingState()
     }
   } catch (e) {
     console.error(e)
     alert('An error occurred while processing. Please try again.')
-    annotationProcessing.value = false
-    annotationButtonText.value = 'Start Annotation Process'
+    resetAnnotationProcessingState()
   }
 }
 

--- a/triplifier/frontend/src/views/AnnotationReviewView.vue
+++ b/triplifier/frontend/src/views/AnnotationReviewView.vue
@@ -16,6 +16,7 @@ const nonMatchingJsonld = ref([])
 const nonMatchingRdfStore = ref([])
 const databasePages = reactive({})
 const expandedDatabases = reactive({})
+const selectedTables = reactive({})
 const annotationProcessing = ref(false)
 const annotationButtonText = ref('Start Annotation Process')
 
@@ -243,9 +244,10 @@ function processAnnotationData(data) {
     return
   }
 
-  for (const td of Object.values(annotated)) {
+  for (const [tableName, td] of Object.entries(annotated)) {
     databasePages[td.rdfStoreName] = 1
     expandedDatabases[td.rdfStoreName] = false
+    selectedTables[tableName] = true
   }
   annotatedTableVariables.value = annotated
   loading.value = false
@@ -299,6 +301,10 @@ function toggleDatabase(name) {
   expandedDatabases[name] = !expandedDatabases[name]
 }
 
+function toggleTableSelection(tableName) {
+  selectedTables[tableName] = !selectedTables[tableName]
+}
+
 function hasValueMapping(varInfo) {
   return (
     varInfo.value_mapping &&
@@ -311,14 +317,70 @@ const startBtnIcon = computed(() =>
   annotationProcessing.value ? 'fa-spinner fa-spin' : 'fa-play'
 )
 
+function createFilteredSemanticMap(selectedTableNames) {
+  if (!semanticMapData.value || !selectedTableNames.length) return semanticMapData.value
+
+  const selectedSet = new Set(selectedTableNames)
+  const filteredMap = JSON.parse(JSON.stringify(semanticMapData.value))
+  
+  if (!filteredMap.databases) return filteredMap
+
+  // Remove unselected tables
+  for (const dbKey in filteredMap.databases) {
+    const db = filteredMap.databases[dbKey]
+    if (!db.tables) continue
+    
+    for (const tableKey in db.tables) {
+      const tableName = db.tables[tableKey].sourceFile || tableKey
+      if (!selectedSet.has(tableName) && !selectedSet.has(tableKey)) {
+        delete db.tables[tableKey]
+      }
+    }
+    
+    if (Object.keys(db.tables).length === 0) {
+      delete filteredMap.databases[dbKey]
+    }
+  }
+
+  return filteredMap
+}
+
 async function startAnnotationProcess() {
   if (!semanticMapData.value) {
     alert('No semantic map data available. Please reload the page.')
     return
   }
+  
+  // Check if any tables are selected
+  const anySelected = Object.values(selectedTables).some(selected => selected)
+  if (!anySelected) {
+    alert('Please select at least one table to annotate.')
+    return
+  }
+  
   annotationProcessing.value = true
   annotationButtonText.value = 'Submitting semantic map...'
   try {
+    // Get the selected table names
+    const selectedTableNames = Object.entries(selectedTables)
+      .filter(([tableName, isSelected]) => isSelected)
+      .map(([tableName]) => tableName)
+
+    // Create a filtered semantic map that only includes selected tables
+    const filteredSemanticMap = createFilteredSemanticMap(selectedTableNames)
+    
+    // Ensure we don't send empty semantic map
+    const hasTables = Object.values(filteredSemanticMap.databases || {}).some(db => 
+      Object.keys(db.tables || {}).length > 0
+    )
+    if (!hasTables) {
+      alert('No tables selected for annotation')
+      annotationProcessing.value = false
+      annotationButtonText.value = 'Start Annotation Process'
+      return
+    }
+
+    // Send FULL semantic map to preserve original for Share page
     const submitRes = await fetch('/submit-indexeddb-semantic-map', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -328,9 +390,7 @@ async function startAnnotationProcess() {
     if (!submitRes.ok || !submit.success) {
       let msg = submit.error || 'Failed to submit semantic map.'
       if (submit.validation_errors?.length) {
-        msg +=
-          '\n\nValidation errors:\n' +
-          submit.validation_errors.map((e) => `- ${e.message}`).join('\n')
+        msg += '\n\nValidation errors:\n' + submit.validation_errors.map((e) => `- ${e.message}`).join('\n')
       }
       alert(msg)
       annotationProcessing.value = false
@@ -338,9 +398,12 @@ async function startAnnotationProcess() {
       return
     }
     annotationButtonText.value = 'Processing Annotations...'
+    
+    // Try sending filtered map to annotation endpoint
     const annRes = await fetch('/start-annotation', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(filteredSemanticMap),
     })
     const ann = await annRes.json()
     if (ann.success) {
@@ -413,15 +476,26 @@ onMounted(load)
           v-for="(dbData, dbName) in annotatedTableVariables"
           :key="dbName"
         >
-          <h2 class="database-heading">
-            <i class="fas fa-database" /> {{ dbData.rdfStoreName }}
-          </h2>
-          <button
-            type="button"
-            class="toggle-button"
-            :class="{ open: expandedDatabases[dbData.rdfStoreName] }"
-            @click="toggleDatabase(dbData.rdfStoreName)"
-          >
+          <div class="database-header">
+            <h2 class="database-heading">
+              <i class="fas fa-database" /> {{ dbData.rdfStoreName }}
+              <span 
+                class="table-selector"
+                @click.stop="toggleTableSelection(dbName)"
+                :class="{ selected: selectedTables[dbName] }"
+              >
+                <i class="fas" :class="selectedTables[dbName] ? 'fa-check' : 'fa-times'" />
+                <span class="selector-tooltip">
+                  {{ selectedTables[dbName] ? 'Deselect for annotation' : 'Select for annotation' }}
+                </span>
+              </span>
+            </h2>
+            <button
+              type="button"
+              class="toggle-button"
+              :class="{ open: expandedDatabases[dbData.rdfStoreName] }"
+              @click="toggleDatabase(dbData.rdfStoreName)"
+            >
             <span class="toggle-text">{{
               expandedDatabases[dbData.rdfStoreName] ? 'Show less' : 'Show more'
             }}</span>
@@ -433,7 +507,8 @@ onMounted(load)
                   : 'fa-chevron-up'
               "
             />
-          </button>
+            </button>
+          </div>
 
           <div
             class="content"
@@ -625,3 +700,89 @@ onMounted(load)
     </div>
   </div>
 </template>
+
+<style scoped>
+.database-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.database-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  flex: 1;
+}
+
+.table-selector {
+  position: relative;
+  cursor: pointer;
+  color: #6c757d;
+  font-size: 0.75em;
+  padding: 2px 4px;
+  border-radius: 3px;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.table-selector:hover {
+  color: #495057;
+  background-color: #f8f9fa;
+}
+
+.table-selector.selected {
+  color: #28a745;
+}
+
+.table-selector.selected:hover {
+  color: #218838;
+  background-color: #f8f9fa;
+}
+
+.selector-tooltip {
+  visibility: hidden;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 6px;
+  padding: 0.25rem 0.5rem;
+  background-color: rgba(0, 0, 0, 0.9);
+  color: #fff;
+  border-radius: 0.25rem;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  z-index: 1080;
+  line-height: 1.5;
+  opacity: 0;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
+}
+
+.selector-tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 0.4rem 0.4rem 0;
+  border-style: solid;
+  border-color: rgba(0, 0, 0, 0.9) transparent transparent;
+}
+
+.table-selector:hover .selector-tooltip {
+  visibility: visible;
+  opacity: 1;
+}
+
+.toggle-button {
+  margin-left: auto;
+  white-space: nowrap;
+}
+</style>

--- a/triplifier/frontend/src/views/AnnotationVerifyView.vue
+++ b/triplifier/frontend/src/views/AnnotationVerifyView.vue
@@ -36,7 +36,8 @@ function changePage(d) {
 function statusIcon(s) {
   if (s === 'success') return 'fa-check-circle success'
   if (s === 'error') return 'fa-times-circle error'
-  if (s === 'undescribed') return 'fa-times-circle error'
+  if (s === 'skipped') return 'fa-minus-circle skipped'
+  if (s === 'undescribed') return 'fa-minus-circle skipped'
   return 'fa-spinner spinner'
 }
 
@@ -59,13 +60,31 @@ async function verifyOne(v) {
 onMounted(async () => {
   try {
     const { data } = await api.get('/api/v1/annotation-verify-state')
-    const described = Object.keys(data.variable_data || {}).map((fullName) => ({
-      fullName,
-      displayName: `${fullName.split('.').slice(-1)[0]} (${fullName.split('.')[0]})`,
-      database: fullName.split('.')[0],
-      status: 'pending',
-      message: 'Checking annotation...',
-    }))
+
+    // Build the set of databases that were actually included in the annotation
+    // run (i.e. appear in annotation_status). Databases absent from this set
+    // were intentionally skipped (filtered out) and should not be shown as
+    // failed — they simply were not annotated.
+    const annotationStatus = data.annotation_status || {}
+    const annotatedDatabases = new Set(
+      Object.keys(annotationStatus).map((key) => key.split('.')[0])
+    )
+    const anyAnnotationRan = Object.keys(annotationStatus).length > 0
+
+    const described = Object.keys(data.variable_data || {}).map((fullName) => {
+      const db = fullName.split('.')[0]
+      // If an annotation run happened but this database was not part of it,
+      // mark the variable as skipped rather than pending (verification would
+      // fail for the wrong reason and mislead the user).
+      const wasSkipped = anyAnnotationRan && !annotatedDatabases.has(db)
+      return {
+        fullName,
+        displayName: `${fullName.split('.').slice(-1)[0]} (${db})`,
+        database: db,
+        status: wasSkipped ? 'skipped' : 'pending',
+        message: wasSkipped ? 'Not annotated' : 'Checking annotation...',
+      }
+    })
     const seen = new Set()
     const undescribed = (data.unannotated_variables || [])
       .map((n) => n.split('.').slice(-1)[0])
@@ -128,6 +147,9 @@ onMounted(async () => {
             <option value="error">
               Failed
             </option>
+            <option value="skipped">
+              Not Annotated
+            </option>
             <option value="pending">
               Pending
             </option>
@@ -144,7 +166,7 @@ onMounted(async () => {
         v-for="v in pageVariables"
         :key="v.fullName"
         class="variable-item"
-        :class="{ unannotated: v.status === 'undescribed' }"
+        :class="{ unannotated: v.status === 'undescribed' || v.status === 'skipped' }"
       >
         <span class="variable-name">{{ v.displayName }}</span>
         <div class="status-indicator">
@@ -190,3 +212,10 @@ onMounted(async () => {
     <br><br>
   </div>
 </template>
+
+<style scoped>
+.success { color: #28a745; }
+.error   { color: #dc3545; }
+.skipped { color: #6c757d; }
+.spinner { color: #6c757d; }
+</style>

--- a/triplifier/frontend/tests/unit/views/AnnotationReviewView.spec.js
+++ b/triplifier/frontend/tests/unit/views/AnnotationReviewView.spec.js
@@ -127,11 +127,13 @@ describe('AnnotationReviewView', () => {
     expect(fetch).toHaveBeenCalledTimes(2)
     expect(fetch.mock.calls[0][0]).toBe('/submit-indexeddb-semantic-map')
     expect(fetch.mock.calls[0][1].method).toBe('POST')
-    // We now send the FULL semantic map to preserve original for Share page
+    // We send the FULL semantic map to preserve original for Share page
     const submittedMap = JSON.parse(fetch.mock.calls[0][1].body)
     expect(submittedMap).toEqual(SEMANTIC_MAP)
     expect(fetch.mock.calls[1][0]).toBe('/start-annotation')
-    expect(JSON.parse(fetch.mock.calls[1][1].body)).toEqual({})
+    // We send the filtered semantic map (all tables selected by default) to annotation endpoint
+    const annotationBody = JSON.parse(fetch.mock.calls[1][1].body)
+    expect(annotationBody).toEqual(SEMANTIC_MAP)
     expect(routerPush).toHaveBeenCalledWith('/annotate/verify')
   })
 
@@ -291,14 +293,17 @@ describe('AnnotationReviewView', () => {
     await flushPromises()
 
     expect(fetch).toHaveBeenCalledTimes(2)
-    // The first call should be to submit the filtered semantic map (only selected databases)
+    // The first call should be to submit the FULL semantic map (to preserve original for Share page)
     const submittedMap = JSON.parse(fetch.mock.calls[0][1].body)
     expect(submittedMap.databases).toBeDefined()
-    // Should only contain the selected database (patients.csv)
+    // Should contain both databases since we send the full map
     expect(submittedMap.databases.db_a).toBeDefined()
-    expect(submittedMap.databases.db_b).toBeUndefined()
-    // The second call to start-annotation with empty body (uses filtered semantic map from session)
+    expect(submittedMap.databases.db_b).toBeDefined()
+    // The second call to start-annotation with filtered semantic map (only selected tables)
     const annotationBody = JSON.parse(fetch.mock.calls[1][1].body)
-    expect(annotationBody).toEqual({})
+    expect(annotationBody.databases).toBeDefined()
+    // Should only contain the selected database (patients.csv)
+    expect(annotationBody.databases.db_a).toBeDefined()
+    expect(annotationBody.databases.db_b).toBeUndefined()
   })
 })

--- a/triplifier/frontend/tests/unit/views/AnnotationReviewView.spec.js
+++ b/triplifier/frontend/tests/unit/views/AnnotationReviewView.spec.js
@@ -127,8 +127,11 @@ describe('AnnotationReviewView', () => {
     expect(fetch).toHaveBeenCalledTimes(2)
     expect(fetch.mock.calls[0][0]).toBe('/submit-indexeddb-semantic-map')
     expect(fetch.mock.calls[0][1].method).toBe('POST')
-    expect(JSON.parse(fetch.mock.calls[0][1].body)).toEqual(SEMANTIC_MAP)
+    // We now send the FULL semantic map to preserve original for Share page
+    const submittedMap = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(submittedMap).toEqual(SEMANTIC_MAP)
     expect(fetch.mock.calls[1][0]).toBe('/start-annotation')
+    expect(JSON.parse(fetch.mock.calls[1][1].body)).toEqual({})
     expect(routerPush).toHaveBeenCalledWith('/annotate/verify')
   })
 
@@ -148,5 +151,154 @@ describe('AnnotationReviewView', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1)
     expect(routerPush).not.toHaveBeenCalled()
+  })
+
+  it('renders table selectors for each database', async () => {
+    api.get.mockResolvedValue({ data: { success: true, databases: ['patients.csv'] } })
+    db.getData.mockImplementation(async (_store, key) => {
+      if (key === 'semantic_map') return { data: SEMANTIC_MAP }
+      return null
+    })
+
+    const w = mountView()
+    await flushPromises()
+
+    expect(w.findAll('.table-selector').length).toBeGreaterThan(0)
+    expect(w.find('.table-selector i.fa-check').exists()).toBe(true)
+  })
+
+  it('has all tables selected by default', async () => {
+    api.get.mockResolvedValue({ data: { success: true, databases: ['patients.csv'] } })
+    db.getData.mockImplementation(async (_store, key) => {
+      if (key === 'semantic_map') return { data: SEMANTIC_MAP }
+      return null
+    })
+
+    const w = mountView()
+    await flushPromises()
+
+    const selectors = w.findAll('.table-selector')
+    expect(selectors.length).toBeGreaterThan(0)
+    
+    // All selectors should have the 'selected' class by default (tables are selected by default)
+    selectors.forEach(selector => {
+      expect(selector.classes()).toContain('selected')
+    })
+  })
+
+  it('toggles table selection when clicking selector', async () => {
+    api.get.mockResolvedValue({ data: { success: true, databases: ['patients.csv'] } })
+    db.getData.mockImplementation(async (_store, key) => {
+      if (key === 'semantic_map') return { data: SEMANTIC_MAP }
+      return null
+    })
+
+    const w = mountView()
+    await flushPromises()
+
+    const firstSelector = w.find('.table-selector')
+    expect(firstSelector.classes()).toContain('selected')
+    expect(firstSelector.find('i.fa-check').exists()).toBe(true)
+
+    await firstSelector.trigger('click')
+    await flushPromises()
+
+    expect(firstSelector.classes()).not.toContain('selected')
+    expect(firstSelector.find('i.fa-times').exists()).toBe(true)
+
+    // Click again to re-select
+    await firstSelector.trigger('click')
+    await flushPromises()
+
+    expect(firstSelector.classes()).toContain('selected')
+    expect(firstSelector.find('i.fa-check').exists()).toBe(true)
+  })
+
+  it('shows alert when trying to annotate with no tables selected', async () => {
+    api.get.mockResolvedValue({ data: { success: true, databases: ['patients.csv'] } })
+    db.getData.mockImplementation(async (_store, key) => {
+      if (key === 'semantic_map') return { data: SEMANTIC_MAP }
+      return null
+    })
+    
+    const alertMock = vi.fn()
+    vi.stubGlobal('alert', alertMock)
+
+    const w = mountView()
+    await flushPromises()
+
+    // Deselect all tables
+    const selectors = w.findAll('.table-selector')
+    for (const selector of selectors) {
+      await selector.trigger('click')
+    }
+    await flushPromises()
+
+    await w.find('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(alertMock).toHaveBeenCalledWith('Please select at least one table to annotate.')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('passes filtered semantic map to annotation endpoint', async () => {
+    // Create a semantic map with two databases
+    const TWO_DB_MAP = {
+      schema: {
+        variables: {
+          age: { predicate: 'roo:P100027', class: 'ncit:C25150', dataType: 'continuous' },
+        },
+      },
+      databases: {
+        db_a: {
+          tables: {
+            patients: {
+              sourceFile: 'patients.csv',
+              columns: { age_col: { mapsTo: 'schema:variable/age', localColumn: 'age' } },
+            },
+          },
+        },
+        db_b: {
+          tables: {
+            other: {
+              sourceFile: 'other.csv',
+              columns: { age_col: { mapsTo: 'schema:variable/age', localColumn: 'age' } },
+            },
+          },
+        },
+      },
+    }
+
+    api.get.mockResolvedValue({ data: { success: true, databases: ['patients.csv', 'other.csv'] } })
+    db.getData.mockImplementation(async (_store, key) => {
+      if (key === 'semantic_map') return { data: TWO_DB_MAP }
+      return null
+    })
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true }))
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true }))
+
+    const w = mountView()
+    await flushPromises()
+
+    // Deselect the second database by clicking its selector
+    const selectors = w.findAll('.table-selector')
+    if (selectors.length > 1) {
+      await selectors[1].trigger('click')
+      await flushPromises()
+    }
+
+    await w.find('button.btn-primary').trigger('click')
+    await flushPromises()
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    // The first call should be to submit the filtered semantic map (only selected databases)
+    const submittedMap = JSON.parse(fetch.mock.calls[0][1].body)
+    expect(submittedMap.databases).toBeDefined()
+    // Should only contain the selected database (patients.csv)
+    expect(submittedMap.databases.db_a).toBeDefined()
+    expect(submittedMap.databases.db_b).toBeUndefined()
+    // The second call to start-annotation with empty body (uses filtered semantic map from session)
+    const annotationBody = JSON.parse(fetch.mock.calls[1][1].body)
+    expect(annotationBody).toEqual({})
   })
 })


### PR DESCRIPTION
### Description

This pull request introduces the following key changes:

- **Table Selection for Filtered Annotation Processing:**
  - Provides a user interface for selecting individual tables for annotation inputs.
  - Implements backend support for validating and processing the filtered semantic maps.
  - Ensures the integrity of the original semantic map by preserving its unaltered state.

- **Clarifications in AnnotationReviewView Tests:**
  - Tests now confirm the full semantic map is submitted for the Share page, while filtered maps are specifically sent for annotation endpoints.
  - Updates ensure the new table selection functionality and backend changes are thoroughly tested.

Should resolve https://github.com/MaastrichtU-CDS/Flyover/issues/92

