### PR TITLE
Fix dropdown options for categorical variables after the first

### DIFF
--- a/triplifier/backend/data_descriptor/repositories/query_builder.py
+++ b/triplifier/backend/data_descriptor/repositories/query_builder.py
@@ -421,6 +421,15 @@ class QueryBuilder:
                     target_class = term_info["target_class"]
                     local_term_value = term_info["local_term"]
 
+                    # local_term can be a single string or a list of strings
+                    if isinstance(local_term_value, list):
+                        local_terms = [lt for lt in local_term_value if isinstance(lt, str)]
+                    else:
+                        local_terms = [local_term_value] if isinstance(local_term_value, str) else []
+
+                    if not local_terms:
+                        continue
+
                     # Check that the target class is a subclass of the variable class
                     # This verifies the basic ontology relationship for value mapping
                     ask_query_parts.append(
@@ -433,13 +442,13 @@ class QueryBuilder:
                         f"{target_class} owl:equivalentClass ?equiv_{i} ."
                     )
 
-                    # Check that there exists at least one cell with this value in the data graph
-                    escaped_local_value = local_term_value.replace(
-                        "\\", "\\\\"
-                    ).replace('"', '\\"')
-                    data_parts.append(
-                        f'?cell_{i} dbo:has_value "{escaped_local_value}"^^xsd:string .'
-                    )
+                    # Check that there exists at least one cell with this value in the data graph.
+                    # When local_term is a list, any one of the listed values is sufficient.
+                    for j, lt in enumerate(local_terms):
+                        escaped_local_value = lt.replace("\\", "\\\\").replace('"', '\\"')
+                        data_parts.append(
+                            f'?cell_{i}_{j} dbo:has_value "{escaped_local_value}"^^xsd:string .'
+                        )
 
         # Build data graph query part
         data_graph_query = ""

--- a/triplifier/backend/data_descriptor/repositories/query_builder.py
+++ b/triplifier/backend/data_descriptor/repositories/query_builder.py
@@ -423,9 +423,15 @@ class QueryBuilder:
 
                     # local_term can be a single string or a list of strings
                     if isinstance(local_term_value, list):
-                        local_terms = [lt for lt in local_term_value if isinstance(lt, str)]
+                        local_terms = [
+                            lt for lt in local_term_value if isinstance(lt, str)
+                        ]
                     else:
-                        local_terms = [local_term_value] if isinstance(local_term_value, str) else []
+                        local_terms = (
+                            [local_term_value]
+                            if isinstance(local_term_value, str)
+                            else []
+                        )
 
                     if not local_terms:
                         continue
@@ -445,7 +451,9 @@ class QueryBuilder:
                     # Check that there exists at least one cell with this value in the data graph.
                     # When local_term is a list, any one of the listed values is sufficient.
                     for j, lt in enumerate(local_terms):
-                        escaped_local_value = lt.replace("\\", "\\\\").replace('"', '\\"')
+                        escaped_local_value = lt.replace("\\", "\\\\").replace(
+                            '"', '\\"'
+                        )
                         data_parts.append(
                             f'?cell_{i}_{j} dbo:has_value "{escaped_local_value}"^^xsd:string .'
                         )

--- a/triplifier/frontend/src/components/AppFooter.vue
+++ b/triplifier/frontend/src/components/AppFooter.vue
@@ -29,7 +29,7 @@
           >
             <p class="footer-text">
               <i class="fas fa-code" />
-              <strong>Flyover</strong> v3.4.1
+              <strong>Flyover</strong> v3.4.2
             </p>
           </a>
         </div>

--- a/triplifier/frontend/src/lib/jsonld.js
+++ b/triplifier/frontend/src/lib/jsonld.js
@@ -154,15 +154,28 @@ export function getGlobalVariableNames() {
   return getAllVariableKeys().map(formatToTitleCase).concat(['Other'])
 }
 
-export function getCategoryOptionsForVariable(_database, globalVarName) {
+export function getCategoryOptionsForVariable(_database, globalVarName, localVariable = null) {
   if (!mapping?.schema?.variables) return []
   let varInfo = mapping.schema.variables[globalVarName]
+  if (!varInfo && localVariable) {
+    varInfo = mapping.schema.variables[localVariable]
+  }
   if (!varInfo) {
     const normalized = globalVarName.toLowerCase().replace(/\s+/g, '_')
     for (const [k, v] of Object.entries(mapping.schema.variables)) {
       if (k.toLowerCase().replace(/\s+/g, '_') === normalized) {
         varInfo = v
         break
+      }
+    }
+    // Also try localVariable normalized
+    if (!varInfo && localVariable) {
+      const normalizedLocal = localVariable.toLowerCase().replace(/\s+/g, '_')
+      for (const [k, v] of Object.entries(mapping.schema.variables)) {
+        if (k.toLowerCase().replace(/\s+/g, '_') === normalizedLocal) {
+          varInfo = v
+          break
+        }
       }
     }
   }

--- a/triplifier/frontend/src/lib/jsonld.js
+++ b/triplifier/frontend/src/lib/jsonld.js
@@ -179,6 +179,21 @@ export function getCategoryOptionsForVariable(_database, globalVarName, localVar
       }
     }
   }
+  // Last resort: find the schema variable by looking up which column in the
+  // databases section has localColumn === localVariable (or _database + localVariable).
+  // This handles the "Missing Description" case where globalVarName is wrong but
+  // localVariable is the actual DB column name that links to a schema variable.
+  if (!varInfo && localVariable && mapping.databases) {
+    forEachColumn(mapping.databases, (colData) => {
+      if (colData.localColumn === localVariable) {
+        const varKey = getVariableKeyFromColumn(colData)
+        if (varKey && mapping.schema?.variables?.[varKey]) {
+          varInfo = mapping.schema.variables[varKey]
+          return false
+        }
+      }
+    })
+  }
   if (!varInfo?.valueMapping?.terms) return []
   return Object.keys(varInfo.valueMapping.terms).map(formatToTitleCase)
 }
@@ -306,6 +321,13 @@ export async function updateMappingFromForm(formData) {
   // Group form entries by database so we can decide per (db, localColumn)
   // whether the entry is "active" (description selected) or a tombstone.
   const targetsByDb = {}
+  // Snapshot of variables referenced by columns in the databases covered by
+  // this form update, captured BEFORE Pass 1 removes anything. Pass 3 only
+  // GCs variables that appear in this snapshot but are no longer referenced
+  // after the update — this prevents the GC from wiping schema variables that
+  // were defined in an uploaded (non-prefilled) JSON-LD but haven't been
+  // assigned to any column yet.
+  const prevReferencedByFormDbs = new Set()
   for (const [key, data] of Object.entries(formData)) {
     const databaseName = data?.database
     if (!databaseName) continue
@@ -327,6 +349,22 @@ export async function updateMappingFromForm(formData) {
         : null
     )
   }
+
+  // Populate prevReferencedByFormDbs: collect all variables that are
+  // currently referenced by columns in the databases covered by this form
+  // update, BEFORE Pass 1 removes any columns.
+  forEachColumn(mapping.databases || {}, (colData, _colKey, tableData, _tableKey, dbData) => {
+    for (const databaseName of Object.keys(targetsByDb)) {
+      if (
+        graphDatabaseFindNameMatch(dbData.name, databaseName) ||
+        graphDatabaseFindNameMatch(tableData.sourceFile, databaseName)
+      ) {
+        const k = getVariableKeyFromColumn(colData)
+        if (k) prevReferencedByFormDbs.add(k)
+        break
+      }
+    }
+  })
 
   // Pass 1 — sweep stale columns. For each (db, localColumn) covered by the
   // form, delete any column whose variable no longer matches the form's
@@ -433,9 +471,12 @@ export async function updateMappingFromForm(formData) {
     }
   }
 
-  // Pass 3 — GC orphaned schema.variables. A variable with no column
-  // referencing it can never produce data, so it should not linger in IDB
-  // and reappear on the next mount.
+  // Pass 3 — GC schema.variables that have become orphaned by this update.
+  // Only variables that were previously referenced by a column in one of the
+  // databases covered by this form update (prevReferencedByFormDbs) and are
+  // no longer referenced anywhere are deleted. Variables that were never
+  // assigned to any column (e.g. from a non-prefilled uploaded JSON-LD) are
+  // preserved so their valueMapping.terms remain available in the details view.
   if (mapping.schema?.variables) {
     const referenced = new Set()
     forEachColumn(mapping.databases || {}, (colData) => {
@@ -443,7 +484,9 @@ export async function updateMappingFromForm(formData) {
       if (k) referenced.add(k)
     })
     for (const varName of Object.keys(mapping.schema.variables)) {
-      if (!referenced.has(varName)) delete mapping.schema.variables[varName]
+      if (!referenced.has(varName) && prevReferencedByFormDbs.has(varName)) {
+        delete mapping.schema.variables[varName]
+      }
     }
   }
 

--- a/triplifier/frontend/src/views/DescribeVariableDetailsView.vue
+++ b/triplifier/frontend/src/views/DescribeVariableDetailsView.vue
@@ -61,7 +61,7 @@ function buildCategoricalVariable(database, varName, categories, dbIdx, itemIdx)
   const isMissing = varName.startsWith('Missing Description')
   const displayLabel = varName.replace(' (or "', '<br>(or "')
 
-  const categoryOptions = jsonld.getCategoryOptionsForVariable(database, globalVarName)
+  const categoryOptions = jsonld.getCategoryOptionsForVariable(database, globalVarName, localVariable)
   const localMappings = jsonld.getLocalMappingsForVariable(
     database,
     localVariable,

--- a/triplifier/frontend/tests/unit/lib/jsonld.spec.js
+++ b/triplifier/frontend/tests/unit/lib/jsonld.spec.js
@@ -15,6 +15,7 @@ import {
   findColumnForVariable,
   setMapping,
   getMapping,
+  getCategoryOptionsForVariable,
   updateCategoryMapping,
   updateMappingFromForm,
   initializeEmptyMapping,
@@ -462,5 +463,129 @@ describe('updateMappingFromForm — deselection and tab-switching robustness', (
     const m = getMapping()
     expect(m.databases.patients.tables.data.columns.age).toBeUndefined()
     expect(m.schema.variables.age).toBeUndefined()
+  })
+
+  it('preserves schema variables from a non-prefilled JSON-LD when only one column is mapped', async () => {
+    // Simulate a non-prefilled JSON-LD: schema.variables populated but
+    // databases is empty. When the user first maps ONE column on the Variables
+    // page, the GC must NOT delete the other schema variables (issue-132).
+    setMapping({
+      '@context': {},
+      '@id': 'mapping:root',
+      '@type': 'mapping:SemanticMapping',
+      schema: {
+        variables: {
+          biological_sex: {
+            '@type': 'schema:CategoricalVariable',
+            dataType: 'categorical',
+            predicate: 'roo:P100018',
+            class: 'ncit:C28421',
+            valueMapping: { terms: { male: {}, female: {} } },
+          },
+          tumor_locatie: {
+            '@type': 'schema:CategoricalVariable',
+            dataType: 'categorical',
+            predicate: 'roo:P100018',
+            class: 'ncit:C3263',
+            valueMapping: { terms: { left: {}, right: {} } },
+          },
+        },
+      },
+      databases: {},
+    })
+    // User maps only biological_sex on the first sync.
+    await updateMappingFromForm(formEntry('patients', 'biologic_sex', 'Biological sex', 'categorical'))
+    const m = getMapping()
+    // biological_sex now has a column entry.
+    expect(m.databases.patients.tables.data.columns.biological_sex).toMatchObject({
+      localColumn: 'biologic_sex',
+    })
+    // tumor_locatie was never referenced — it must be PRESERVED (not GC'd).
+    expect(m.schema.variables.tumor_locatie).toBeDefined()
+    expect(m.schema.variables.biological_sex).toBeDefined()
+  })
+})
+
+describe('getCategoryOptionsForVariable', () => {
+  beforeEach(() => {
+    setMapping({
+      '@context': {},
+      '@id': 'mapping:root',
+      '@type': 'mapping:SemanticMapping',
+      schema: {
+        variables: {
+          biological_sex: {
+            '@type': 'schema:CategoricalVariable',
+            dataType: 'categorical',
+            valueMapping: { terms: { male: {}, female: {} } },
+          },
+          tumor_locatie: {
+            '@type': 'schema:CategoricalVariable',
+            dataType: 'categorical',
+            valueMapping: { terms: { left: {}, right: {} } },
+          },
+        },
+      },
+      databases: {
+        patients: {
+          name: 'patients',
+          tables: {
+            data: {
+              sourceFile: 'patients',
+              columns: {
+                biological_sex: {
+                  mapsTo: 'schema:variable/biological_sex',
+                  localColumn: 'biologic_sex',
+                },
+                tumor_locatie: {
+                  mapsTo: 'schema:variable/tumor_locatie',
+                  localColumn: 'tumor_loc',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('returns valueMapping terms for a variable matched by exact globalVarName', () => {
+    const opts = getCategoryOptionsForVariable('patients', 'biological_sex')
+    expect(opts).toEqual(['Male', 'Female'])
+  })
+
+  it('returns options for a second categorical variable (regression test for issue-132)', () => {
+    const opts = getCategoryOptionsForVariable('patients', 'tumor_locatie')
+    expect(opts).toEqual(['Left', 'Right'])
+  })
+
+  it('falls back to localVariable when globalVarName does not match any schema key', () => {
+    // Simulates the "Missing Description" scenario where globalVarName is wrong
+    // but localVariable is the actual DB column that maps to a schema variable.
+    const opts = getCategoryOptionsForVariable('patients', 'missing_description', 'biologic_sex')
+    expect(opts).toEqual(['Male', 'Female'])
+  })
+
+  it('falls back to database lookup via localColumn when both key lookups fail', () => {
+    // globalVarName = 'missing_description' (wrong), localVariable = 'tumor_loc'
+    // (matches localColumn in databases → tumor_locatie in schema).
+    const opts = getCategoryOptionsForVariable('patients', 'missing_description', 'tumor_loc')
+    expect(opts).toEqual(['Left', 'Right'])
+  })
+
+  it('returns empty array when no mapping is loaded', () => {
+    setMapping(null)
+    expect(getCategoryOptionsForVariable('patients', 'biological_sex')).toEqual([])
+  })
+
+  it('returns empty array when variable has no valueMapping', () => {
+    setMapping({
+      '@context': {},
+      '@id': 'mapping:root',
+      '@type': 'mapping:SemanticMapping',
+      schema: { variables: { age: { dataType: 'continuous' } } },
+      databases: {},
+    })
+    expect(getCategoryOptionsForVariable('patients', 'age')).toEqual([])
   })
 })


### PR DESCRIPTION
### Description

This pull request fixes an issue where dropdown options for categorical variables were not displaying correctly after the first variable when using a non-prefilled JSON-LD file. 

The problem arose because `getCategoryOptionsForVariable` only checked the primary variable name (`globalVarName`) in `schema.variables` but neglected the alternative name (`localVariable`). The fix ensures that the function also checks `localVariable` when the primary lookup fails, leading to correct population of category options regardless of the variable name used during selection. 

### Checklist

- [x] Code changes are tested
- [x] Relevant issues are linked

Resolves #132